### PR TITLE
Update escalation logic to allow for non-escalating issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,36 +1,3 @@
-*.py[cod]
-
-# C extensions
-*.so
-
-# Packages
-*.egg
-*.egg-info
-dist
-build
-eggs
-parts
-./bin
-sdist
-develop-eggs
-.installed.cfg
-lib
-lib64
-__pycache__
-
-# Installer logs
-pip-log.txt
-
-# Unit test / coverage reports
-.coverage
-.tox
-nosetests.xml
-htmlcov
-.pytest_cache
-
-# Translations
-*.mo
-
 # Mr Developer
 .mr.developer.cfg
 .project
@@ -44,20 +11,115 @@ htmlcov
 !container_fs/*
 src/.cache
 
-# Virtual environments
-env/
-venv/
-.ENV/
-
 # Project specific
 output/
-target/.history
 comet_core.sublime-project
 comet_core.sublime-workspace
 comet_core.code-workspace
-.cache/
 .vscode/
 test-reports/
 
-# Pyenv versions
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
 .python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/comet_core/app.py
+++ b/comet_core/app.py
@@ -478,14 +478,7 @@ class Comet:
                 if source_type in self.real_time_config_providers:
                     event_config = self.real_time_config_providers[source_type](event)
 
-                # This pattern is used instead of .get since escalate_cadence is allowed to
-                # be falsy, but also missing.
-                # If it is explicitly set to a falsy value, that should be honoured and
-                # escalation should not take place, but if it is missing it should default
-                # to 36H.
-                escalate_cadence = (
-                    event_config["escalate_cadence"] if "escalate_cadence" in event_config else timedelta(hours=36)
-                )
+                escalate_cadence = event_config.get("escalate_cadence", timedelta(hours=36))
 
                 if escalate_cadence:
                     event_sent_at = event.sent_at

--- a/comet_core/app.py
+++ b/comet_core/app.py
@@ -484,7 +484,7 @@ class Comet:
                 # escalation should not take place, but if it is missing it should default
                 # to 36H.
                 escalate_cadence = (
-                    event_config["escalate_cadence"] if "escalate_config" in event_config else timedelta(hours=36)
+                    event_config["escalate_cadence"] if "escalate_cadence" in event_config else timedelta(hours=36)
                 )
 
                 if escalate_cadence:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import setuptools
 
 setuptools.setup(
     name="comet-core",
-    version="2.2.0",
+    version="2.3.0",
     url="https://github.com/spotify/comet-core",
     author="Spotify Platform Security",
     author_email="wasabi@spotify.com",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -554,7 +554,7 @@ def test_handle_default_escalation_strategy(app):
     escalator = mock.Mock()
     app.register_escalator("real_time_source", func=escalator)
 
-    # This event should not be escalated.
+    # This event should be escalated once
     app.data_store.add_record(
         EventRecord(
             id=2,


### PR DESCRIPTION
This is achieved by setting escalate_cadence to a falsy value. To
not break existing functionality/backwards compatibility, events
still defaults to 36H escalation.

**THIS PR IS A WORK IN PROGRESS AND IS NOT YET READY TO BE MERGED.**