### PR TITLE
non-digest batch mode

### DIFF
--- a/comet_core/app.py
+++ b/comet_core/app.py
@@ -459,6 +459,8 @@ class Comet:
                         self.data_store.update_processed_at_timestamp_to_now(events)
                     except CometCouldNotSendException:
                         LOG.error(f"Could not send alert to {owner}: {events}")
+                else:
+                    self.data_store.update_processed_at_timestamp_to_now(events)
 
                 LOG.info("events-processed", extra={"events": len(events), "source-type": source_type, "owner": owner})
 

--- a/comet_core/app.py
+++ b/comet_core/app.py
@@ -521,8 +521,11 @@ class Comet:
         """
         if real_time_events_by_owner:
             for owner, events in real_time_events_by_owner.items():
-                self._route_events(owner, events, source_type)
-                self.data_store.update_processed_at_timestamp_to_now(events)
+                try:
+                    self._route_events(owner, events, source_type)
+                    self.data_store.update_processed_at_timestamp_to_now(events)
+                except CometCouldNotSendException:
+                    LOG.error(f"Could not send alert to {owner}: {events}")
 
     def _handle_events_need_escalation(self, source_type, needs_escalation_events):
         """Handle events need escalation by getting the escalate

--- a/comet_core/data_store.py
+++ b/comet_core/data_store.py
@@ -55,7 +55,7 @@ def remove_duplicate_events(event_record_list):
     return event_record_list
 
 
-class DataStore:
+class DataStore: # pylint: disable=too-many-public-methods
     """Abstraction of the comet storage layer.
 
     Args:
@@ -167,6 +167,32 @@ class DataStore:
         if timestamps:
             return max(timestamps)[0] <= datetime.utcnow() - search_timedelta
         return False
+
+    def get_any_issues_need_reminder(self, search_timedelta, records):
+        """Returns all the `fingerprints` having corresponding `event` table entries with the latest `sent_at`
+        more then search_timedelta ago.
+        NOTE: if all database records for a fingerprint given in the `records` list have the sent_at values set to Null,
+              then this fingerprint will be treated as NOT needing a reminder, which might be unintuitive.
+        Args:
+            search_timedelta (datetime.timedelta): reminder interval
+            records (list): list of EventRecord objects to check
+        Returns:
+            list: list of fingerprints that represent issues that need to be reminded about
+        """
+        fingerprints = [record.fingerprint for record in records]
+        fingerprints_to_remind = (
+            self.session.query(func.max(EventRecord.sent_at).label("sent_at"), EventRecord.fingerprint)
+            .filter(EventRecord.fingerprint.in_(fingerprints) & EventRecord.sent_at.isnot(None))
+            .group_by(EventRecord.fingerprint)
+            .all()
+        )
+        result = []
+        deltat = datetime.utcnow() - search_timedelta
+        for f in fingerprints_to_remind:
+            if f.sent_at <= deltat:
+                result.append(f.fingerprint)
+
+        return result
 
     def update_timestamp_column_to_now(self, records, column_name):
         """Update the `column_name` of the provided `EventRecord`s to datetime now

--- a/comet_core/data_store.py
+++ b/comet_core/data_store.py
@@ -55,7 +55,7 @@ def remove_duplicate_events(event_record_list):
     return event_record_list
 
 
-class DataStore: # pylint: disable=too-many-public-methods
+class DataStore:  # pylint: disable=too-many-public-methods
     """Abstraction of the comet storage layer.
 
     Args:

--- a/comet_core/fingerprint.py
+++ b/comet_core/fingerprint.py
@@ -14,9 +14,9 @@
 
 """Helper function to compute the fingerprint of alerts."""
 
-import collections
 import hmac
 import json
+from collections.abc import Iterable
 from copy import deepcopy
 from hashlib import sha256, shake_256
 
@@ -62,7 +62,7 @@ def filter_dict(orig_dict, blacklist):
     for item in blacklist:
         if isinstance(item, str) and item in orig_dict:
             del orig_dict[item]
-        elif isinstance(item, collections.Iterable):
+        elif isinstance(item, Iterable):
             pointer = orig_dict
             for sub in item[:-1]:
                 pointer = pointer.get(sub, {})

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import setuptools
 
 setuptools.setup(
     name="comet-core",
-    version="2.5.2",
+    version="2.6.0",
     url="https://github.com/spotify/comet-core",
     author="Spotify Platform Security",
     author_email="wasabi@spotify.com",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import setuptools
 
 setuptools.setup(
     name="comet-core",
-    version="2.5.0",
+    version="2.5.2",
     url="https://github.com/spotify/comet-core",
     author="Spotify Platform Security",
     author_email="wasabi@spotify.com",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -200,7 +200,7 @@ def test_process_unprocessed_events_non_digest_mode():
     assert app.data_store.get_latest_event_with_fingerprint("f7").processed_at
     assert router.call_count == before_calling + 1
 
-    sent_fingerprints = [e.fingerprint for e in router.call_args.args[2]]
+    sent_fingerprints = [e.fingerprint for e in router.call_args[0][2]]
     assert "f5" in sent_fingerprints
     assert "f6" in sent_fingerprints
     assert "f7" not in sent_fingerprints

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -25,13 +25,13 @@ from comet_core.app import EventContainer
 from comet_core.model import EventRecord, IgnoreFingerprintRecord
 
 
-@freeze_time("2018-05-09 09:00:00")
 # pylint: disable=missing-docstring
-def test_process_unprocessed_events():
+def test_process_unprocessed_events_digest_mode():
     app = Comet()
     app.register_parser("datastoretest", json)
     app.register_parser("datastoretest2", json)
     app.register_parser("datastoretest3", json)
+    app.register_parser("datastoretest4", json)
 
     app.set_config("datastoretest2", {})
 
@@ -91,9 +91,14 @@ def test_process_unprocessed_events():
     )
 
     app.process_unprocessed_events()
+
+    # it is expected to have specific_router called once for the datastoretest2
     assert specific_router.call_count == 1
+    # it is expected to have two calls of the generic router for the source_type datastoretest2 and datastoretest3
     assert router.call_count == 2
+    # and the user must be check_user
     assert router.call_args[0][2][0].owner == check_user
+    # due to the default escalation_time=10seconds, all three events (id=2,3,4) must be escalated
     assert escalator.call_count == 3
 
     app.data_store.add_record(
@@ -103,12 +108,102 @@ def test_process_unprocessed_events():
             source_type="datastoretest",
             owner=check_user,
             data={},
-            fingerprint="f4",
+            fingerprint="f1",
         )
     )
     app.process_unprocessed_events()
-    assert app.data_store.get_latest_event_with_fingerprint('f4').processed_at
 
+    # f1 is expected to be processed, but not sent out
+    assert app.data_store.get_latest_event_with_fingerprint("f1").processed_at
+    assert not app.data_store.get_latest_event_with_fingerprint("f1").sent_at
+
+
+# pylint: disable=missing-docstring
+def test_process_unprocessed_events_non_digest_mode():
+    app = Comet()
+    app.register_parser("datastoretest4", json)
+
+    check_user = "an_owner"
+    router = mock.Mock()
+    escalator = mock.Mock()
+    app.register_router(func=router)
+    app.register_escalator(func=escalator)
+
+    app.set_config("datastoretest4", {"communication_digest_mode": False, "new_threshold": timedelta(days=14)})
+
+    app.data_store.add_record(
+        EventRecord(
+            id=6,
+            received_at=datetime.utcnow() - timedelta(days=8),
+            source_type="datastoretest4",
+            sent_at=datetime.utcnow() - timedelta(days=8),
+            processed_at=datetime.utcnow() - timedelta(days=8),
+            owner=check_user,
+            data={},
+            fingerprint="f5",
+        )
+    )
+
+    app.data_store.add_record(
+        EventRecord(
+            id=7,
+            received_at=datetime.utcnow() - timedelta(days=2),
+            source_type="datastoretest4",
+            owner=check_user,
+            data={},
+            fingerprint="f5",
+        )
+    )
+
+    app.data_store.add_record(
+        EventRecord(
+            id=8,
+            received_at=datetime.utcnow(),
+            source_type="datastoretest4",
+            owner=check_user,
+            data={},
+            fingerprint="f6",
+        )
+    )
+
+    app.data_store.add_record(
+        EventRecord(
+            id=9,
+            received_at=datetime.utcnow() - timedelta(days=2),
+            source_type="datastoretest4",
+            sent_at=datetime.utcnow() - timedelta(days=2),
+            processed_at=datetime.utcnow() - timedelta(days=2),
+            owner=check_user,
+            data={},
+            fingerprint="f7",
+        )
+    )
+
+    app.data_store.add_record(
+        EventRecord(
+            id=10,
+            received_at=datetime.utcnow(),
+            source_type="datastoretest4",
+            owner=check_user,
+            data={},
+            fingerprint="f7",
+        )
+    )
+
+    # f5 is expected to be reminded
+    # f6 is expected to be new and sent as well
+    # f7 is NOT expected to be reminded
+    before_calling = router.call_count
+    app.process_unprocessed_events()
+    assert app.data_store.get_latest_event_with_fingerprint("f5").processed_at
+    assert app.data_store.get_latest_event_with_fingerprint("f6").processed_at
+    assert app.data_store.get_latest_event_with_fingerprint("f7").processed_at
+    assert router.call_count == before_calling + 1
+
+    sent_fingerprints = [e.fingerprint for e in router.call_args.args[2]]
+    assert "f5" in sent_fingerprints
+    assert "f6" in sent_fingerprints
+    assert "f7" not in sent_fingerprints
 
 
 def test_event_container():

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -96,6 +96,20 @@ def test_process_unprocessed_events():
     assert router.call_args[0][2][0].owner == check_user
     assert escalator.call_count == 3
 
+    app.data_store.add_record(
+        EventRecord(
+            id=5,
+            received_at=datetime.utcnow() - timedelta(days=2),
+            source_type="datastoretest",
+            owner=check_user,
+            data={},
+            fingerprint="f4",
+        )
+    )
+    app.process_unprocessed_events()
+    assert app.data_store.get_latest_event_with_fingerprint('f4').processed_at
+
+
 
 def test_event_container():
     container = EventContainer("test", {})


### PR DESCRIPTION
By default (digest mode), all batch events will be grouped by an owner and source_type.
we email will look like:
here are your X new issues, and by the way, you have these Y old ones.

This PR adds non-digest mode, so the router will receive only these events that are new or need a reminder.

