### PR TITLE
set cache_ok to true for typeDecorator

### DIFF
--- a/comet_core/model.py
+++ b/comet_core/model.py
@@ -45,6 +45,8 @@ class JSONType(types.TypeDecorator):  # pylint: disable=abstract-method
 
     impl = UnicodeText
 
+    cache_ok = True
+
     def load_dialect_impl(self, dialect):
         """This is an end-user override hook that can be used to provide
         differing types depending on the given dialect.

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import setuptools
 
 setuptools.setup(
     name="comet-core",
-    version="2.8.1",
+    version="2.8.2",
     url="https://github.com/spotify/comet-core",
     author="Spotify Platform Security",
     author_email="wasabi@spotify.com",


### PR DESCRIPTION
set cache_ok to true for typeDecorator to avoid SQLAlchemy warnings


<!-- Provide a general summary of your changes in the title field above -->

## Description
<!-- Describe your changes in detail -->

## Checklist

<!-- Go over all the following points, and put an `x` in the boxes that applies. -->

- [ ] Changes are covered by tests.
- [ ] Documentation has been updated with the new changes.
- [ ] Readme is still relevant after the changes has been introduced.
- [ ] Library version is updated in `setup.py`.  
      _Required to make a new release._
