### PR TITLE
Remove stderr log handler and formatter

### DIFF
--- a/comet_core/__init__.py
+++ b/comet_core/__init__.py
@@ -12,22 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""comet - Comet Distributed Security Notification System"""
+"""Comet - Comet Distributed Security Notification System"""
 
 __author__ = "Spotify Security Wasabi team <wasabi@spotify.com>"
 __all__ = ["Comet"]
 
-import logging
-
-from pythonjsonlogger import jsonlogger
-
 from comet_core.app import Comet
 from comet_core.exceptions import CometAlertException, CometBaseException, CometCouldNotSendException
-
-root_logger = logging.getLogger()
-
-stderr_handler = logging.StreamHandler()
-stderr_handler.setFormatter(
-    jsonlogger.JsonFormatter("%(asctime)s %(levelname)s %(name)s %(message)s", "%Y-%m-%dT%H:%M:%S")
-)
-root_logger.addHandler(stderr_handler)

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import setuptools
 
 setuptools.setup(
     name="comet-core",
-    version="2.9.0",
+    version="2.10.0",
     url="https://github.com/spotify/comet-core",
     author="Spotify Platform Security",
     author_email="wasabi@spotify.com",
@@ -24,7 +24,7 @@ setuptools.setup(
     long_description=open("README.md", "r+", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     packages=["comet_core"],
-    install_requires=["Flask~=2.0", "Flask-Cors~=3.0", "python-json-logger~=2.0", "SQLAlchemy~=1.4"],
+    install_requires=["Flask~=2.0", "Flask-Cors~=3.0", "SQLAlchemy~=1.4"],
     include_package_data=True,
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Remove the log handler and formatter, including python-json-logger
dependency.

It is better to let the Comet implementation deal with the log handlers
and formatters and let those settings be inherited to the library.

This is a potential breaking change if an implementation do not
configure its' own logger/formatter.

## Checklist

<!-- Go over all the following points, and put an `x` in the boxes that applies. -->

- [ ] ~Changes are covered by tests.~
- [X] Documentation has been updated with the new changes.
- [X] Readme is still relevant after the changes has been introduced.
- [X] Library version is updated in `setup.py`.  
      _Required to make a new release._
